### PR TITLE
Add ExtensionVersion.remote and as_dict, and Extension.as_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+## 0.0.3 (2018-06-21)
+
+* Add `remote(basename)` method to `ExtensionVersion`, to return the contents of a file within the extension.
+* Add `as_dict()` method to `Extension` and `ExtensionVersion`, to avoid returning private properties.
+
 ## 0.0.2 (2018-06-12)
 
-* Make `ExtensionRegistry` iterable.
+* Add `get(**kwargs)` method to `ExtensionRegistry`, to get a specific extension version.
+* Make `ExtensionRegistry` iterable, to iterate over all extension versions.
 * Remove `all()` method from `ExtensionRegistry`.
-* Add `get(**kwargs)` method to `ExtensionRegistry`.
 * Add package-specific exceptions.
 
 ## 0.0.1 (2018-06-11)

--- a/ocdsextensionregistry/extension.py
+++ b/ocdsextensionregistry/extension.py
@@ -6,3 +6,11 @@ class Extension:
         self.id = data['Id']
         self.category = data['Category']
         self.core = data['Core'] == 'true'
+
+    def as_dict(self):
+        """
+        Returns the object's properties as a dictionary.
+
+        This method is defined to match the method in `ExtensionVersion`.
+        """
+        return self.__dict__

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -11,10 +11,21 @@ def test_init():
 
 
 def test_init_non_core():
-    for core in ('TRUE', 'True', 'false', 'foo', ''):
+    for core in ('TRUE', 'True', 'false', 'foo', '', None):
         obj = Extension(arguments(Core=core))
 
         assert obj.core is False
+
+
+def test_as_dict():
+    args = arguments(Core='')
+    obj = Extension(args)
+
+    assert obj.as_dict() == {
+        'id': args['Id'],
+        'category': args['Category'],
+        'core': False,
+    }
 
 
 def arguments(**kwargs):

--- a/tests/test_extension_registry.py
+++ b/tests/test_extension_registry.py
@@ -42,7 +42,7 @@ def test_init_with_data():
     obj = ExtensionRegistry(extension_versions_data, extensions_data)
 
     assert len(obj.versions) == 14
-    assert obj.versions[0].__dict__ == {
+    assert obj.versions[0].as_dict() == {
         'id': 'charges',
         'date': '',
         'version': 'master',
@@ -52,7 +52,7 @@ def test_init_with_data():
         'core': False,
     }
     # Assume intermediate data is correctly parsed.
-    assert obj.versions[-1].__dict__ == {
+    assert obj.versions[-1].as_dict() == {
         'id': 'lots',
         'date': '2018-01-30',
         'version': 'v1.1.3',
@@ -67,7 +67,7 @@ def test_init_with_versions_only():
     obj = ExtensionRegistry(extension_versions_data)
 
     assert len(obj.versions) == 14
-    assert obj.versions[0].__dict__ == {
+    assert obj.versions[0].as_dict() == {
         'id': 'charges',
         'date': '',
         'version': 'master',
@@ -75,7 +75,7 @@ def test_init_with_versions_only():
         'download_url': 'https://github.com/open-contracting/ocds_charges_extension/archive/master.zip',
     }
     # Assume intermediate data is correctly parsed.
-    assert obj.versions[-1].__dict__ == {
+    assert obj.versions[-1].as_dict() == {
         'id': 'lots',
         'date': '2018-01-30',
         'version': 'v1.1.3',
@@ -89,7 +89,7 @@ def test_filter():
     result = obj.filter(core=True, version='v1.1.3', category='tender')
 
     assert len(result) == 2
-    assert result[0].__dict__ == {
+    assert result[0].as_dict() == {
         'id': 'enquiries',
         'date': '2018-02-01',
         'version': 'v1.1.3',
@@ -98,7 +98,7 @@ def test_filter():
         'category': 'tender',
         'core': True,
     }
-    assert result[1].__dict__ == {
+    assert result[1].as_dict() == {
         'id': 'lots',
         'date': '2018-01-30',
         'version': 'v1.1.3',
@@ -121,7 +121,7 @@ def test_get():
     obj = ExtensionRegistry(extension_versions_data)
     result = obj.get(id='lots', version='v1.1.3')
 
-    assert result.__dict__ == {
+    assert result.as_dict() == {
         'id': 'lots',
         'date': '2018-01-30',
         'version': 'v1.1.3',


### PR DESCRIPTION
Add `remote(basename)` method to `ExtensionVersion`, to return the contents of a file within the extension. Add `as_dict()` method to `Extension` and `ExtensionVersion`, to avoid returning private properties.