### PR TITLE
Fix edge case so that `metadata` language maps are ordered, even if `…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.6
+
+* Fix edge case so that `metadata` language maps are ordered, even if `extension.json` didn't have language maps.
+
 ## 0.0.5 (2018-10-31)
 
 * Add `ProfileBuilder`, `Codelist`, `CodelistCode` classes.

--- a/ocdsextensionregistry/extension_version.py
+++ b/ocdsextensionregistry/extension_version.py
@@ -1,6 +1,7 @@
 import csv
 import os.path
 import re
+from collections import OrderedDict
 from contextlib import closing
 from io import BytesIO, StringIO
 from urllib.parse import urlparse
@@ -101,7 +102,7 @@ class ExtensionVersion:
                     self._metadata[field] = {}
                 # Add language maps.
                 if not isinstance(self._metadata[field], dict):
-                    self._metadata[field] = {'en': self._metadata[field]}
+                    self._metadata[field] = OrderedDict({'en': self._metadata[field]})
 
             if 'compatibility' not in self._metadata or isinstance(self._metadata['compatibility'], str):
                 self._metadata['compatibility'] = ['1.1']

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst') as f:
 
 setup(
     name='ocdsextensionregistry',
-    version='0.0.5',
+    version='0.0.6',
     author='Open Contracting Partnership',
     author_email='data@open-contracting.org',
     url='https://github.com/open-contracting/extension_registry.py',


### PR DESCRIPTION
…extension.json` didn't have language maps